### PR TITLE
Add templates to cabal file for new-install

### DIFF
--- a/umu-halogen.cabal
+++ b/umu-halogen.cabal
@@ -15,7 +15,13 @@ maintainer:          piq9117@gmail.com
 -- copyright:
 -- category:
 build-type:          Simple
-extra-source-files:  CHANGELOG.md
+extra-source-files:    CHANGELOG.md
+                     , templates/Makefile
+                     , templates/*.html
+                     , templates/*.js
+                     , templates/*.json
+                     , templates/*.dhall
+                     , templates/*.purs
 
 library
   exposed-modules:     UmuHalogen


### PR DESCRIPTION
To install via `cabal new-install` the `extra-source-files` must include the templates

Fixes #1 